### PR TITLE
Returning README to proper $config example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ How to use
    ```php
    <?php
    // Using Facebook strategy as an example
-   $config['Opauth']['Config']['Strategy']['Facebook'] = [
+   $config['Opauth']['Strategy']['Facebook'] = [
         'app_id' => 'YOUR FACEBOOK APP ID',
         'app_secret' => 'YOUR FACEBOOK APP SECRET'
    ];


### PR DESCRIPTION
The original example for $config was correct, I misunderstood the code.